### PR TITLE
Commit Log

### DIFF
--- a/commitlog.py
+++ b/commitlog.py
@@ -6,7 +6,7 @@ class CommitLog:
         self.fd = fd
 
     @classmethod 
-    def resume(self, log_path):
+    def resume(cls, log_path):
         memtable = Memtable()
         fd = None
         # recover the memtable if necessary
@@ -22,7 +22,7 @@ class CommitLog:
                 record = fd.readline()
         else:
             fd = open(log_path, 'w')
-        return CommitLog(fd), memtable
+        return cls(fd), memtable
 
     def record_set(self, k, v):
         self.fd.write(f"{k},{v}\n")


### PR DESCRIPTION
### Description
This PR adds an implementation for the commit log. Currently, we just write it as a CSV, but this will change in the future. When we initialize the `CommitLog` it will check if the log is already on disk. If there is a log on disk, it is possible the db crashed, so we try to rebuild the state of the memtable.

The `CommitLog` interface is implemented as follows:
- `CommitLog.resume(log_path)` creates a new `CommitLog` and `Memtable`, loads the memtable from disk if necessary, and returns a tuple of `(CommitLog, Memtable)`
- `record_set(k, v)` records a set operation on disk
- `record_unset(k)` records an unset operation on disk
- `purge()` wipes the current log

### Usage
Initialize the `CommitLog` and `Memtable`. Here `mt` would either be a fresh memtable, or a memtable loaded from disk after a crash:
```
$ cl, mt = CommitLog.resume('/tmp/log.csv')
```
Record a set, or unset operation:
```
$ cl.record_set('key', 'value')
$ cl.record_unset('key')
```
Wipe the commit log:
```
$ cl.purge()
```
