### PR TITLE
Sstable

### DIFF
--- a/sstable.py
+++ b/sstable.py
@@ -1,17 +1,18 @@
-from contextlib import contextmanager
 from os import path
 
 from memtable import TOMBSTONE
 
 
 class SSTable:
+    """Represents a Sorted-String-Table (SSTable) on disk"""
 
     def __init__(self, sstable_path):
         self.path = sstable_path
         self.fd = None
 
     def write(self, memtable):
-        with self.open('w'):
+        self.fd = open(self.path, 'w')
+        with open(self.path, 'w'):
             for (key, value) in memtable.entries():
                 if value == TOMBSTONE:
                     entry = f"{key},\n"
@@ -21,17 +22,10 @@ class SSTable:
 
     def search(self, search_key):
         if path.exists(self.path):
-            with self.open('r') as sstable:
-                for line in sstable.fd:
+            self.fd = open(self.path, 'r')
+            with open(self.path, 'r') as sstable:
+                for line in sstable:
                     (key, value) = line.rstrip().split(',')
                     if key == search_key:
                         if value:
                             return value
-
-    @contextmanager
-    def open(self, mode):
-        try:
-            self.fd = open(self.path, mode)
-            yield self
-        finally:
-            self.fd.close()


### PR DESCRIPTION
### Description

This PR adds an implementation for the sstable. Currently, we just write it as a CSV, but this will change in the future. 

The SSTable interface is implemented as follows:

    write(memtable) writes memtable entries to disk sstable
    search(search_key) search for key from disk sstable

### Usage

Import SSTable and Memtable
```
from sstable import SSTable
from memtable import Memtable
```

Initialize the Memtable. Write to memtable
```
mt = Memtable()
for n in range(0, 5):
    mt.set(str(n), str(n * 2))
```

Initialize a SSTable, write memtable to sstable
```
sstable = SSTable('sstable_path')
sstable.write(mt)
```

Search for a key
```
print(sstable.search('1'))
```