### PR TITLE
Segments

### DIFF
--- a/segments.py
+++ b/segments.py
@@ -10,11 +10,11 @@ class Segments:
         self.segment_dir = segment_dir
         self.segments = []
         if path.isdir(self.segment_dir):
-            self.__load_segments()
+            self._load_segments()
         else:
             mkdir(self.segment_dir)
     
-    def __load_segments(self):
+    def _load_segments(self):
         segment_files = []
         with scandir(self.segment_dir) as files:
             for f in files:

--- a/sstable.py
+++ b/sstable.py
@@ -12,9 +12,9 @@ class SSTable:
         self.path = path
         self.bf = bf
         if not self.bf:
-            self.__sync()
+            self._sync()
 
-    def __sync(self):
+    def _sync(self):
         self.bf = BloomFilter(BF_SIZE, BF_HASH_COUNT)
         for (key, value) in self.entries():
             self.bf.add(key)


### PR DESCRIPTION
### Overview
This PR adds the `Segments` module, for managing disk segments. `Segments` maintains a stack of `SSTable` instances in memory, and reloads them during initialization. Eventually, it will also provide compaction capabillities.

The `Segments` interface is implemented as follows:
- `flush(memtable)` flush a memtable to a new disk segment, and update the in-memory stack
- `search(k : string)` searches the segments, from newest to oldest for the given key

### Basic Usage
Create a `Segments` instance, by providing a directory path for storing segments.
```
$ s = Segments('/tmp/segments')
```
Next, create and populate a `Memtable`.
```
$ mt = Memtable()
$ for n in range(0, 100):
$     mt.set(str(n), str(n*2))
```
Flush the `Memtable` to disk.
```
$ s.flush(mt)
```
Verify a new `SSTable` was created in the directory.
```
$ ls -l /tmp/segments
total 4
-rw-r--r-- 1 rob rob 635 Jul 24 17:44 segment-1.dat
```
```
$ head -n 5 /tmp/segments/segment-1.dat 
0,0
1,2
10,20
11,22
12,24
```
Search for some keys.
```
$ s.search('50')
'100'
```
```
$  s.search('123') == None
True
```
Flush another `Memtable` with updated values, and verify we get the new value.
```
$ mt = Memtable()
$ for n in range(0, 100):
$     mt.set(str(n), str(n*3))
$ s.flush(mt)
```
```
$ ls -l /tmp/segments
total 8
-rw-r--r-- 1 rob rob 635 Jul 24 17:44 segment-1.dat
-rw-r--r-- 1 rob rob 652 Jul 24 17:51 segment-2.dat
```
```
$ s.search('50')
'150'
```

### TOMBSTONEs
Using the `Segments` instance from the examples above, create another `Memtable`, with updated values.
```
$ mt = Memtable()
$ for n in range(0, 100):
$     mt.set(str(n), str(n*4))
```
Before we flush, delete a key that was set.
```
$ mt.unset('50')
```
Flush the new contents.
```
$ s.flush(mt)
```
Verify the segment was created.
```
$ ls -l /tmp/segments
total 12
-rw-r--r-- 1 rob rob 635 Jul 24 17:44 segment-1.dat
-rw-r--r-- 1 rob rob 652 Jul 24 17:51 segment-2.dat
-rw-r--r-- 1 rob rob 659 Jul 24 17:55 segment-3.dat
```
Search for the deleted key.
```
$ s.search('50')
<memtable.Tombstone object at 0x7f1b0bb801d0>
```

### Debugging

#### SSTable Stack
You can access the stack with `s.segments`, the newest segment is always first.
```
$ s.segments
[<sstable.SSTable object at 0x7f1b0b9bed50>, <sstable.SSTable object at 0x7f1b0b9bb650>, <sstable.SSTable object at 0x7f1b0b9ab750>]
```
Extract the contents of an `SSTable`.
```
$ list(s.segments[0].entries())
[['0', '0'], ['1', '4'], ['10', '40'], ['11', '44'], ['12', '48'], ['13', '52'], ['14', '56'], ['15', '60'], ['16', '64'], ['17', '68'], ['18', '72'], ['19', '76'], ['2', '8'], ['20', '80'], ...
```

#### Bloom Filters
With the segments we created above, we can inspect the individual `BloomFilter`s to see if they are helping us avoid full-scans.
```
$ sum([1 if s.segments[0].bf.exists(str(k)) else 0 for k in range(0, 100000)])
100
```
