### PR TITLE
Fix double unset bug calling len on Tombstone.

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,4 +1,7 @@
+from typing import Union
+
 class Tombstone:
     pass
 
 TOMBSTONE = Tombstone()
+Value = Union[str, Tombstone]

--- a/memtable.py
+++ b/memtable.py
@@ -1,4 +1,6 @@
-from common import TOMBSTONE
+from typing import Iterator, Optional, Tuple
+
+from common import TOMBSTONE, Value
 from rbtree import RBTree, inorder_traversal
 
 class Memtable:
@@ -6,23 +8,25 @@ class Memtable:
         self.bytes = 0
         self.tree = RBTree()
 
-    def set(self, k, v):
+    def set(self, k: str, v: str) -> None:
         self.bytes += len(k) + len(v)
         self.tree.insert(k, v)
 
-    def get(self, k):
+    def get(self, k: str) -> Optional[Value]:
         return self.tree.search(k)
 
-    def unset(self, k):
+    def unset(self, k: str) -> None:
         value = self.get(k)
-        if value:
-            self.bytes -= len(value)
+        if value is TOMBSTONE:
+            return
+        if value is not None:
+            self.bytes -= len(value) #type: ignore [arg-type]
         else:
             self.bytes += len(k)
         self.tree.insert(k, TOMBSTONE)
 
-    def entries(self):
+    def entries(self) -> Iterator[Tuple[str, str]]:
         yield from inorder_traversal(self.tree.root)
  
-    def approximate_bytes(self):
+    def approximate_bytes(self) -> int:
         return self.bytes

--- a/tests/test_memtable_state_machine.py
+++ b/tests/test_memtable_state_machine.py
@@ -1,0 +1,65 @@
+import os
+import tempfile
+from typing import Dict
+
+import hypothesis.strategies as st
+from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
+
+from common import TOMBSTONE, Value
+from memtable import Memtable
+
+
+class MemtableDictComparison(RuleBasedStateMachine):
+    def __init__(self):
+        super().__init__()
+        _, self.tempf = tempfile.mkstemp()
+        self.memtable = Memtable()
+        self.model: Dict[str, Value] = dict()
+
+    keys = Bundle("keys")
+    values = Bundle("values")
+
+    @rule(target=keys, key=st.text())
+    def add_key(self, key: str) -> str:
+        return key
+
+    @rule(target=values, value=st.text())
+    def add_value(self, value: str) -> str:
+        return value
+
+    @rule(key=keys, value=values)
+    def set(self, key: str, value: str):
+        self.model[key] = value
+        self.memtable.set(key, value)
+
+    @rule(key=keys)
+    def unset(self, key: str):
+        self.model[key] = TOMBSTONE
+        self.memtable.unset(key)
+
+    @rule(key=keys)
+    def values_agree(self, key: str):
+        assert self.memtable.get(key) == self.model.get(key, None)
+
+    @rule()
+    def memtable_is_ordered(self):
+        assert list(self.memtable.entries()) == sorted(self.memtable.entries())
+
+    # TODO: Current bytes bug (issue #31) breaks this rule
+    # @rule()
+    # def approximate_bytes_reflects_what_is_in_model(self):
+    #     def add_up_bytes():
+    #         bytes_ = 0
+    #         for (key, value) in self.model.items():
+    #             if value is TOMBSTONE:
+    #                 bytes_ += len(key)
+    #             else:
+    #                 bytes_ += len(key) + len(value) #type: ignore [arg-type]
+    #         return bytes_
+    #     assert self.memtable.approximate_bytes() == add_up_bytes()
+
+    def teardown(self):
+        os.remove(self.tempf)
+
+
+TestMemtable = MemtableDictComparison.TestCase


### PR DESCRIPTION
This fixes the bug where unseting a value twice calls len on a tombstone. I also added a check that value is not None so avoid the case of empty strings. Also added types.

## Before
![image](https://user-images.githubusercontent.com/33668612/90842234-c5833d00-e32c-11ea-8b44-9d8cf20ff4b3.png)

## After
![image](https://user-images.githubusercontent.com/33668612/90842362-12671380-e32d-11ea-8fed-e106c2290362.png)

The test is a state machine based test that compares the memtable to a dictionary. Things get set and unset in the dictionary along with the memtable and then we check that the two data structures agree with each other. On rule is commented out that highlights an issue with the bytes thing in #31.